### PR TITLE
Address problem with .NET CLR Memory perf counters not being recorded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,4 @@ src/Web.Analyst.SPA/Content/styles.css
 src/Web.Analyst.SPA/Content/styles.css.map
 src/Web.Analyst.SPA/Content/styles.min.css
 src/Web.Analyst.SPA/Content/styles.min.css.map
+/src/.idea

--- a/src/Agent.Test/SetUp.cs
+++ b/src/Agent.Test/SetUp.cs
@@ -50,6 +50,7 @@ namespace Gibraltar.Agent.Test
 
             publisher.ApplicationDescription = "NUnit tests of the Gibraltar Agent Library";
 
+            m_Configuration.Listener.EnableMemoryPerformance = true;
             m_Configuration.SessionFile.EnableFilePruning = false;
             m_Configuration.ExportFile.Folder = @"C:\Data\Export";
 

--- a/src/AgentTest/App.config
+++ b/src/AgentTest/App.config
@@ -2,15 +2,15 @@
 <configuration>
   <configSections>
     <sectionGroup name="gibraltar">
-      <section name="listener" type="Gibraltar.Agent.ListenerElement, Loupe.Core"/>
-      <section name="packager" type="Gibraltar.Agent.PackagerElement, Loupe.Core"/>
-      <section name="publisher" type="Gibraltar.Agent.PublisherElement, Loupe.Core"/>
-      <section name="sessionFile" type="Gibraltar.Agent.SessionFileElement, Loupe.Core"/>
-      <section name="exportFile" type="Gibraltar.Agent.ExportFileElement, Loupe.Core"/>
-      <section name="viewer" type="Gibraltar.Agent.ViewerElement, Loupe.Core"/>
-      <section name="email" type="Gibraltar.Agent.EmailElement, Loupe.Core"/>
-      <section name="server" type="Gibraltar.Agent.ServerElement, Loupe.Core"/>
-      <section name="networkViewer" type="Gibraltar.Agent.NetworkViewerElement, Loupe.Core"/>
+      <section name="listener" type="Gibraltar.Agent.ListenerElement, Gibraltar.Agent"/>
+      <section name="packager" type="Gibraltar.Agent.PackagerElement, Gibraltar.Agent"/>
+      <section name="publisher" type="Gibraltar.Agent.PublisherElement, Gibraltar.Agent"/>
+      <section name="sessionFile" type="Gibraltar.Agent.SessionFileElement, Gibraltar.Agent"/>
+      <section name="exportFile" type="Gibraltar.Agent.ExportFileElement, Gibraltar.Agent"/>
+      <section name="viewer" type="Gibraltar.Agent.ViewerElement, Gibraltar.Agent"/>
+      <section name="email" type="Gibraltar.Agent.EmailElement, Gibraltar.Agent"/>
+      <section name="server" type="Gibraltar.Agent.ServerElement, Gibraltar.Agent"/>
+      <section name="networkViewer" type="Gibraltar.Agent.NetworkViewerElement, Gibraltar.Agent"/>
       <section name="properties" type="System.Configuration.NameValueSectionHandler"/>
     </sectionGroup>
   </configSections>
@@ -27,7 +27,7 @@
   <system.diagnostics>
     <trace>
       <listeners>
-        <add name="gibraltar" type="Gibraltar.Agent.LogListener, Loupe.Agent.Internal"/>
+        <add name="gibraltar" type="Gibraltar.Agent.LogListener, Gibraltar.Agent"/>
       </listeners>
     </trace>
   </system.diagnostics>

--- a/src/AgentTest/Program.cs
+++ b/src/AgentTest/Program.cs
@@ -134,6 +134,7 @@ namespace Gibraltar.Agent.Test
 
             Log.MessageAlert += Log_ErrorAlertNotification;
 
+            e.Configuration.Listener.EnableMemoryPerformance = true;
             /*
             e.Configuration.Listener.EnableDiskPerformance = false;
             e.Configuration.Listener.EnableNetworkPerformance = false;

--- a/src/Core/Monitor/PerfCounterCollection.cs
+++ b/src/Core/Monitor/PerfCounterCollection.cs
@@ -212,7 +212,7 @@ namespace Gibraltar.Monitor
         {
             //cause every performance counter to log itself.
 
-            //we are going to do this in two passes:  One to get all of the samples, the second to write them to the log file.  This 
+            //we are going to do this in two passes:  One to get all the samples, the second to write them to the log file.  This 
             //will let us write them as a single call and minimize locking.
             List<MetricSample> samples = new List<MetricSample>(Count);
 


### PR DESCRIPTION
Customer reported cases where users don't get .NET CLR memory perf counters recorded and this warning is added to the log:

Unable to record performance information for .NET memory counters:
Specific exception: System.InvalidOperationException
Exception message: Category does not exist.

Reviewing our implementation, these are process instance counters which rely on the routine we use to determine what the unique instance name is for the application.

This PR improves that logic with:
1. Default to the process name so it can always do an initial filter of the list to check (speeding up the first check)
2. If it gets an unauthorized access exception attempting to open the counters it needs to determine the right instance name it just uses the process name.  This would only be inaccurate if there are multiple copies of the application running at the same time - so it's better than always failing for a user in that scenario.
3. If it runs into any other error or a blank counter it'll let the exception roll through, so we'll record a better message than the above, which happened because the code attempted to just use a blank instance name.