### PR TITLE
Correct event handling & search text loading for live view

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,7 +58,7 @@ jobs:
     displayName: 'Sign NuGet Packages'  
     inputs:
       command: 'custom'
-      arguments: sign $(Build.ArtifactStagingDirectory)\packages\*.nupkg -CertificatePath $(Cert_Storage_Path)/gibraltarsoftwareccc.cer -CertificatePassword $(Cert_Password)-Timestamper http://timestamp.comodoca.com -Verbosity detailed
+      arguments: sign $(Build.ArtifactStagingDirectory)\packages\*.nupkg -CertificatePath $(Cert_Storage_Path)/gibraltarsoftwareccc.cer -CertificatePassword $(Cert_Password) -Timestamper http://timestamp.comodoca.com -Verbosity detailed
 
   - task: NuGetCommand@2
     displayName: 'Sign NuGet Symbol Packages'  

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,13 +24,6 @@ jobs:
       secureFile: 'loupe.agent.snk'
       overWrite: true
 
-  - task: DownloadSecureFile@1
-    displayName: 'Download Code Signing Cert'  
-    name: GibraltarSoftwareCCC
-    inputs:
-      secureFile: 'GibraltarSoftwareCCC.pfx'
-      overWrite: true
-
   - task: CopyFiles@2
     displayName: 'Copy Signing Key to Build Location'  
     inputs:
@@ -65,13 +58,13 @@ jobs:
     displayName: 'Sign NuGet Packages'  
     inputs:
       command: 'custom'
-      arguments: sign $(Build.ArtifactStagingDirectory)\packages\*.nupkg -CertificatePath $(Agent.TempDirectory)/GibraltarSoftwareCCC.pfx -CertificatePassword f4rd+GM% -Timestamper http://timestamp.comodoca.com -Verbosity detailed
+      arguments: sign $(Build.ArtifactStagingDirectory)\packages\*.nupkg -CertificatePath $(Cert_Storage_Path)/gibraltarsoftwareccc.cer -CertificatePassword $(Cert_Password)-Timestamper http://timestamp.comodoca.com -Verbosity detailed
 
   - task: NuGetCommand@2
     displayName: 'Sign NuGet Symbol Packages'  
     inputs:
       command: 'custom'
-      arguments: sign $(Build.ArtifactStagingDirectory)\packages\*.snupkg -CertificatePath $(Agent.TempDirectory)/GibraltarSoftwareCCC.pfx -CertificatePassword f4rd+GM% -Timestamper http://timestamp.comodoca.com -Verbosity detailed
+      arguments: sign $(Build.ArtifactStagingDirectory)\packages\*.snupkg -CertificatePath $(Cert_Storage_Path)/gibraltarsoftwareccc.cer -CertificatePassword $(Cert_Password) -Timestamper http://timestamp.comodoca.com -Verbosity detailed
 
   - task: PublishBuildArtifacts@1
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,6 +2,9 @@ name: $(major).$(minor).$(revision)$(Rev:.r)
 trigger:
 - main
 
+pool:
+  name: 'Dedicated Build Server'
+
 variables:
   agentSolution: 'src\Agent.sln'
   buildPlatform: 'Any CPU'
@@ -14,7 +17,7 @@ variables:
 jobs:
 - job: build
   pool:
-    vmImage: 'windows-latest'
+    name: 'Dedicated Build Server'
 
   steps:
   - task: DownloadSecureFile@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,18 +57,6 @@ jobs:
       flattenFolders: true
       targetFolder: '$(Build.ArtifactStagingDirectory)\packages'
 
-  - task: NuGetCommand@2
-    displayName: 'Sign NuGet Packages'  
-    inputs:
-      command: 'custom'
-      arguments: sign $(Build.ArtifactStagingDirectory)\packages\*.nupkg -CertificatePath '$(Cert_Storage_Path)\gibraltarsoftwareccc.cer' -CertificatePassword $(Cert_Password) -Timestamper http://timestamp.comodoca.com -Verbosity detailed
-
-  - task: NuGetCommand@2
-    displayName: 'Sign NuGet Symbol Packages'  
-    inputs:
-      command: 'custom'
-      arguments: sign $(Build.ArtifactStagingDirectory)\packages\*.snupkg -CertificatePath '$(Cert_Storage_Path)\gibraltarsoftwareccc.cer' -CertificatePassword $(Cert_Password) -Timestamper http://timestamp.comodoca.com -Verbosity detailed
-
   - task: PublishBuildArtifacts@1
     inputs:
       pathToPublish: '$(Build.ArtifactStagingDirectory)\packages'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,13 +58,13 @@ jobs:
     displayName: 'Sign NuGet Packages'  
     inputs:
       command: 'custom'
-      arguments: sign $(Build.ArtifactStagingDirectory)\packages\*.nupkg -CertificatePath $(Cert_Storage_Path)/gibraltarsoftwareccc.cer -CertificatePassword $(Cert_Password) -Timestamper http://timestamp.comodoca.com -Verbosity detailed
+      arguments: sign $(Build.ArtifactStagingDirectory)\packages\*.nupkg -CertificatePath '$(Cert_Storage_Path)\gibraltarsoftwareccc.cer' -CertificatePassword $(Cert_Password) -Timestamper http://timestamp.comodoca.com -Verbosity detailed
 
   - task: NuGetCommand@2
     displayName: 'Sign NuGet Symbol Packages'  
     inputs:
       command: 'custom'
-      arguments: sign $(Build.ArtifactStagingDirectory)\packages\*.snupkg -CertificatePath $(Cert_Storage_Path)/gibraltarsoftwareccc.cer -CertificatePassword $(Cert_Password) -Timestamper http://timestamp.comodoca.com -Verbosity detailed
+      arguments: sign $(Build.ArtifactStagingDirectory)\packages\*.snupkg -CertificatePath '$(Cert_Storage_Path)\gibraltarsoftwareccc.cer' -CertificatePassword $(Cert_Password) -Timestamper http://timestamp.comodoca.com -Verbosity detailed
 
   - task: PublishBuildArtifacts@1
     inputs:

--- a/src/Core/Monitor/Windows/LiveLogViewer.Designer.cs
+++ b/src/Core/Monitor/Windows/LiveLogViewer.Designer.cs
@@ -385,9 +385,8 @@
             this.SearchToolStripTextBox.Name = "SearchToolStripTextBox";
             this.SearchToolStripTextBox.Size = new System.Drawing.Size(150, 25);
             this.SearchToolStripTextBox.Text = "Search Messages";
-            this.SearchToolStripTextBox.Enter += new System.EventHandler(this.SearchToolStripTextBox_Enter);
-            this.SearchToolStripTextBox.Leave += new System.EventHandler(this.SearchToolStripTextBox_Leave);
-            this.SearchToolStripTextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.SearchToolStripTextBox_KeyDown);
+            this.SearchToolStripTextBox.GotFocus += new System.EventHandler(this.SearchToolStripTextBox_GotFocus);
+            this.SearchToolStripTextBox.LostFocus += new System.EventHandler(this.SearchToolStripTextBox_LostFocus);
             this.SearchToolStripTextBox.TextChanged += new System.EventHandler(this.SearchToolStripTextBox_TextChanged);
             // 
             // SearchToolStripButton


### PR DESCRIPTION
Addresses issues #23 and #24.  Additionally, hardens the way it detects if it should show the cue text for search.  Additionally:

1. Slight performance improvement by doing a single ToLower on the merged string instead of doing each individual string which would make a copy.
2. Limits the search text to the first 16kB of the log search text to avoid excessive memory usage.
