### PR TITLE
Add ability to disable clever memory optimizations

### DIFF
--- a/src/Agent/Configuration/PublisherConfiguration.cs
+++ b/src/Agent/Configuration/PublisherConfiguration.cs
@@ -29,8 +29,8 @@ namespace Gibraltar.Agent.Configuration
         /// product name from the assemblies that initiate logging.</remarks>
         public string ProductName
         {
-            get { return m_WrappedConfiguration.ProductName; }
-            set { m_WrappedConfiguration.ProductName = value; }
+            get => m_WrappedConfiguration.ProductName;
+            set => m_WrappedConfiguration.ProductName = value;
         }
 
         /// <summary>
@@ -41,8 +41,8 @@ namespace Gibraltar.Agent.Configuration
         /// application description from the assemblies that initiate logging.</remarks>
         public string ApplicationDescription
         {
-            get { return m_WrappedConfiguration.ApplicationDescription; }
-            set { m_WrappedConfiguration.ApplicationDescription = value; }
+            get => m_WrappedConfiguration.ApplicationDescription;
+            set => m_WrappedConfiguration.ApplicationDescription = value;
         }
 
         /// <summary>
@@ -53,8 +53,8 @@ namespace Gibraltar.Agent.Configuration
         /// product name from the assemblies that initiate logging.</remarks>
         public string ApplicationName
         {
-            get { return m_WrappedConfiguration.ApplicationName; }
-            set { m_WrappedConfiguration.ApplicationName = value; }
+            get => m_WrappedConfiguration.ApplicationName;
+            set => m_WrappedConfiguration.ApplicationName = value;
         }
 
         /// <summary>
@@ -67,8 +67,8 @@ namespace Gibraltar.Agent.Configuration
         /// for the application could have undesirable effects.</remarks>
         public ApplicationType ApplicationType // Note: Should it restrict certain detectable mismatches?
         {
-            get { return (ApplicationType)m_WrappedConfiguration.ApplicationType; }
-            set { m_WrappedConfiguration.ApplicationType = (Loupe.Extensibility.Data.ApplicationType)value; }
+            get => (ApplicationType)m_WrappedConfiguration.ApplicationType;
+            set => m_WrappedConfiguration.ApplicationType = (Loupe.Extensibility.Data.ApplicationType)value;
         }
 
         /// <summary>
@@ -79,8 +79,8 @@ namespace Gibraltar.Agent.Configuration
         /// product name from the assemblies that initiate logging.</para></remarks>
         public Version ApplicationVersion
         {
-            get { return m_WrappedConfiguration.ApplicationVersion; }
-            set { m_WrappedConfiguration.ApplicationVersion = value; }
+            get => m_WrappedConfiguration.ApplicationVersion;
+            set => m_WrappedConfiguration.ApplicationVersion = value;
         }
 
 
@@ -93,8 +93,8 @@ namespace Gibraltar.Agent.Configuration
         /// corresponding entry does not exist it will be automatically created.</remarks>
         public string EnvironmentName
         {
-            get { return m_WrappedConfiguration.EnvironmentName; }
-            set { m_WrappedConfiguration.EnvironmentName = value; }
+            get => m_WrappedConfiguration.EnvironmentName;
+            set => m_WrappedConfiguration.EnvironmentName = value;
         }
 
         /// <summary>
@@ -106,8 +106,8 @@ namespace Gibraltar.Agent.Configuration
         /// If the corresponding entry does not exist it will be automatically created.</remarks>
         public string PromotionLevelName
         {
-            get { return m_WrappedConfiguration.PromotionLevelName; }
-            set { m_WrappedConfiguration.PromotionLevelName = value; }
+            get => m_WrappedConfiguration.PromotionLevelName;
+            set => m_WrappedConfiguration.PromotionLevelName = value;
         }
 
         /// <summary>
@@ -119,8 +119,8 @@ namespace Gibraltar.Agent.Configuration
         /// configured messenger.</remarks>
         public bool ForceSynchronous
         {
-            get { return m_WrappedConfiguration.ForceSynchronous; }
-            set { m_WrappedConfiguration.ForceSynchronous = value; }
+            get => m_WrappedConfiguration.ForceSynchronous;
+            set => m_WrappedConfiguration.ForceSynchronous = value;
         }
 
         /// <summary>
@@ -131,8 +131,8 @@ namespace Gibraltar.Agent.Configuration
         /// catch up.  This will cause the client to block until each new message is published.</remarks>
         public int MaxQueueLength
         {
-            get { return m_WrappedConfiguration.MaxQueueLength; }
-            set { m_WrappedConfiguration.MaxQueueLength = value; }
+            get => m_WrappedConfiguration.MaxQueueLength;
+            set => m_WrappedConfiguration.MaxQueueLength = value;
         }
 
         /// <summary>
@@ -143,8 +143,8 @@ namespace Gibraltar.Agent.Configuration
         /// by default, and normal operation will collect this information automatically.</remarks>
         public bool EnableAnonymousMode
         {
-            get { return m_WrappedConfiguration.EnableAnonymousMode; }
-            set { m_WrappedConfiguration.EnableAnonymousMode = value; }
+            get => m_WrappedConfiguration.EnableAnonymousMode;
+            set => m_WrappedConfiguration.EnableAnonymousMode = value;
         }
 
         /// <summary>
@@ -158,9 +158,27 @@ namespace Gibraltar.Agent.Configuration
         /// just silently ignore. Therefore, this option is not recommended for consistent production use.</para></remarks>
         public bool EnableDebugMode
         {
-            get { return m_WrappedConfiguration.EnableDebugMode; }
-            set { m_WrappedConfiguration.EnableDebugMode = value; }
+            get => m_WrappedConfiguration.EnableDebugMode;
+            set => m_WrappedConfiguration.EnableDebugMode = value;
         }
+
+
+        /// <summary>
+        /// When true, the Agent will not do string compression and other optimizations to minimize memory.
+        /// </summary>
+        /// <remarks><para>The Agent normally works to minimize memory use in production scenarios, such as
+        /// using a string cache to avoid keeping duplicate strings in memory and other steps.  These steps
+        /// rely on .NET Garbage Collector features; if there are GC issues in the process they can be
+        /// confusing to debug and understand using conventional profilers while these optimizations are being
+        /// used.</para>
+        /// <para>Setting this option to true will disable these optimizations which will increase the memory used by 
+        /// the agent (particularly for log message buffering) but makes a simpler picture for memory profiling.</para></remarks>
+        public bool DisableMemoryOptimization
+        {
+            get => m_WrappedConfiguration.DisableMemoryOptimization;
+            set => m_WrappedConfiguration.DisableMemoryOptimization = value;
+        }
+
 
         #endregion
     }

--- a/src/AgentTest/App.config
+++ b/src/AgentTest/App.config
@@ -15,7 +15,7 @@
     </sectionGroup>
   </configSections>
   <gibraltar>
-    <publisher productName="Demo" applicationName="AgentTest"/>
+    <publisher productName="Demo" applicationName="AgentTest" disableMemoryOptimization="false"/>
     <server useGibraltarService="true" customerName="Nonexistent" autoSendSessions="true" sendAllApplications="false" purgeSentSessions="false"/>
     <packager destinationEmailAddress="No-Reply@GibraltarSoftware.com" allowFile="true" allowRemovableMedia="true" allowEmail="true" productName="Demo" applicationName=""/>
     <!-- <listener reportErrorsToUsers="false" /> Mono doesn't support multiple UI threads -->

--- a/src/Common/StringReference.cs
+++ b/src/Common/StringReference.cs
@@ -20,7 +20,7 @@ namespace Gibraltar
         private static readonly object s_Lock = new object(); //Multithread Protection lock
         private static Dictionary<int, WeakStringCollection> s_StringReferences = new Dictionary<int, WeakStringCollection>(DefaultCollectionSize); //PROTECTED BY LOCK
 
-        private volatile static bool s_DisableCache;
+        private static volatile bool s_DisableCache;
         private static long s_PeakReferenceSize; //PROTECTED BY LOCK
 
         /// <summary>
@@ -30,14 +30,8 @@ namespace Gibraltar
         /// behavior with and without the cache without changing code.</remarks>
         public static bool Disabled
         {
-            get
-            {
-                return s_DisableCache;
-            }
-            set
-            {
-                s_DisableCache = value;
-            }
+            get => s_DisableCache;
+            set => s_DisableCache = value;
         }
 
         /// <summary>

--- a/src/Core/Agent/LoupeElementBase.cs
+++ b/src/Core/Agent/LoupeElementBase.cs
@@ -44,7 +44,7 @@ namespace Gibraltar.Agent
         }
 
         /// <summary>
-        /// Invoked to load all of the environment variables that match the configuration elements for this section.
+        /// Invoked to load all the environment variables that match the configuration elements for this section.
         /// </summary>
         /// <param name="environmentVars"></param>
         protected abstract void OnLoadEnvironmentVars(IDictionary<string, string> environmentVars);

--- a/src/Core/Agent/PublisherElement.cs
+++ b/src/Core/Agent/PublisherElement.cs
@@ -31,8 +31,9 @@ namespace Gibraltar.Agent
             LoadEnvironmentVariable(environmentVars, "maxQueueLength");
             LoadEnvironmentVariable(environmentVars, "enableAnonymousMode");
             LoadEnvironmentVariable(environmentVars, "enableDebugMode");
+            LoadEnvironmentVariable(environmentVars, "disableMemoryOptimization");
         }
-        
+
         /// <summary>
         /// Optional.  The name of the product for logging purposes.
         /// </summary>
@@ -169,6 +170,7 @@ namespace Gibraltar.Agent
             get => ReadBoolean("enableAnonymousMode");
             set => this["enableAnonymousMode"] = value;
         }
+
         /// <summary>
         /// When true, the Agent will include debug messages in logs. Not intended for production use
         /// </summary>
@@ -183,6 +185,23 @@ namespace Gibraltar.Agent
         {
             get => ReadBoolean("enableDebugMode");
             set => this["enableDebugMode"] = value;
+        }
+
+        /// <summary>
+        /// When true, the Agent will not do string compression and other optimizations to minimize memory.
+        /// </summary>
+        /// <remarks><para>The Agent normally works to minimize memory use in production scenarios, such as
+        /// using a string cache to avoid keeping duplicate strings in memory and other steps.  These steps
+        /// rely on .NET Garbage Collector features; if there are GC issues in the process they can be
+        /// confusing to debug and understand using conventional profilers while these optimizations are being
+        /// used.</para>
+        /// <para>Setting this option to true will disable these optimizations which will increase the memory used by 
+        /// the agent (particularly for log message buffering) but makes a simpler picture for memory profiling.</para></remarks>
+        [ConfigurationProperty("disableMemoryOptimization", DefaultValue = false, IsRequired = false)]
+        public bool DisableMemoryOptimization
+        {
+            get => ReadBoolean("disableMemoryOptimization");
+            set => this["disableMemoryOptimization"] = value;
         }
     }
 }

--- a/src/Core/Monitor/Log.cs
+++ b/src/Core/Monitor/Log.cs
@@ -96,10 +96,10 @@ namespace Gibraltar.Monitor
 
         private static LogMessageSeverity s_MinimumSeverity = LogMessageSeverity.Verbose; //protected by being static and simple assignment
 
-        private volatile static bool s_Initialized; //protected by being volatile
-        private volatile static bool s_InitializationNeverAttempted = true; //protected by being volatile
-        private volatile static bool s_Initializing; //PROTECTED BY INITIALIZING and volatile
-        private volatile static bool s_ExplicitStartSessionCalled; // protected by being volatile
+        private static volatile bool s_Initialized; //protected by being volatile
+        private static volatile bool s_InitializationNeverAttempted = true; //protected by being volatile
+        private static volatile bool s_Initializing; //PROTECTED BY INITIALIZING and volatile
+        private static volatile bool s_ExplicitStartSessionCalled; // protected by being volatile
         private static bool s_StartupConsentDisplayed; //protected by CONSENT LOCK
 
         private static Notifier s_MessageAlertNotifier; // PROTECTED BY NOTIFIERLOCK (weak check outside lock allowed)
@@ -2441,6 +2441,9 @@ namespace Gibraltar.Monitor
             //if we're in debug mode then force the central silent mode option.
             if (s_RunningConfiguration.Publisher.EnableDebugMode)
                 Log.SilentMode = false;
+
+            if (s_RunningConfiguration.Publisher.DisableMemoryOptimization)
+                StringReference.Disabled = true;
 
             s_SessionStartInfo = new SessionSummary(s_RunningConfiguration);
 

--- a/src/Core/Monitor/PublisherConfiguration.cs
+++ b/src/Core/Monitor/PublisherConfiguration.cs
@@ -1,6 +1,4 @@
-﻿
-
-using System;
+﻿using System;
 using System.Configuration;
 using System.Xml;
 using Gibraltar.Agent;
@@ -41,6 +39,7 @@ namespace Gibraltar.Monitor
             //copy the provided configuration
             if (node != null)
             {
+                DisableMemoryOptimization = AgentConfiguration.ReadValue(node, "disableMemoryOptimization", baseline.DisableMemoryOptimization);
                 EnableAnonymousMode = AgentConfiguration.ReadValue(node, "enableAnonymousMode", baseline.EnableAnonymousMode);
                 EnableDebugMode = AgentConfiguration.ReadValue(node, "enableDebugMode", baseline.EnableDebugMode);
                 ForceSynchronous = AgentConfiguration.ReadValue(node, "forceSynchronous", baseline.ForceSynchronous);
@@ -181,6 +180,18 @@ namespace Gibraltar.Monitor
         public bool EnableDebugMode { get; set; }
 
         /// <summary>
+        /// When true, the Agent will not do string compression and other optimizations to minimize memory.
+        /// </summary>
+        /// <remarks><para>The Agent normally works to minimize memory use in production scenarios, such as
+        /// using a string cache to avoid keeping duplicate strings in memory and other steps.  These steps
+        /// rely on .NET Garbage Collector features; if there are GC issues in the process they can be
+        /// confusing to debug and understand using conventional profilers while these optimizations are being
+        /// used.</para>
+        /// <para>Setting this option to true will disable these optimizations which will increase the memory used by 
+        /// the agent (particularly for log message buffering) but makes a simpler picture for memory profiling.</para></remarks>
+        public bool DisableMemoryOptimization { get; set; }
+
+        /// <summary>
         /// Save the configuration to the specified XML node.
         /// </summary>
         /// <param name="gibraltarNode"></param>
@@ -200,6 +211,7 @@ namespace Gibraltar.Monitor
             AgentConfiguration.WriteValue(newNode, "maxQueueLength", MaxQueueLength, baseline.MaxQueueLength);
             AgentConfiguration.WriteValue(newNode, "enableAnonymousMode", EnableAnonymousMode, baseline.EnableAnonymousMode);
             AgentConfiguration.WriteValue(newNode, "enableDebugMode", EnableDebugMode, baseline.EnableDebugMode);
+            AgentConfiguration.WriteValue(newNode, "disableMemoryOptimization", DisableMemoryOptimization, baseline.DisableMemoryOptimization);
 
             if (ApplicationVersion != null)
             {
@@ -242,6 +254,7 @@ namespace Gibraltar.Monitor
         private void Initialize(PublisherElement configuration)
         {
             //copy the configuration
+            DisableMemoryOptimization = configuration.DisableMemoryOptimization;
             EnableAnonymousMode = configuration.EnableAnonymousMode;
             EnableDebugMode = configuration.EnableDebugMode;
             ForceSynchronous = configuration.ForceSynchronous;


### PR DESCRIPTION
To address a customer reported issue where the string refererence collection wasn't being cleaned up, we'll add the ability to disable it.

Reviewing customer telemetry, it appears there is an exception happening elsewhere in their application during garbage collection which has the knock-on effect that the single instance string store is ballooning memory.